### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
-RUN apt update && \
-    apt install jq wget -y && \
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
+RUN apt-get update && \
+    apt-get install ca-certificates jq wget --yes --no-install-recommends && \
     wget https://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list && \
-    apt update --allow-insecure-repositories && \
-    apt -y --allow-unauthenticated install --reinstall d-apt-keyring && \
-    apt update && \
-    apt install dmd-compiler dub -y && \
-    apt clean && \
+    apt-get update --allow-insecure-repositories && \
+    apt-get --yes --no-install-recommends --allow-unauthenticated install --reinstall d-apt-keyring && \
+    apt-get update && \
+    apt-get install dmd-compiler dub --yes --no-install-recommends && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/test-runner

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 RUN apt update && \
     apt install jq wget -y && \
     wget https://master.dl.sourceforge.net/project/d-apt/files/d-apt.list -O /etc/apt/sources.list.d/d-apt.list && \


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.